### PR TITLE
Add chefignore file

### DIFF
--- a/.chefignore
+++ b/.chefignore
@@ -53,6 +53,8 @@ test/*
 features/*
 Guardfile
 Procfile
+.rubocop.yml
+Rakefile
 .kitchen
 .kitchen.*
 dockerfiles


### PR DESCRIPTION
As is mentioned in this page https://docs.chef.io/chef_repo.html#chefignore-files we must add this file to prevent useless insertions of files during the making of the tarball.
