### PR TITLE
add attributes git_sync_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ If you've used [rbenv][rbenv] or [pyenv][pyenv], this is a port of that concept 
     <td><tt>master</tt></td>
   </tr>
   <tr>
+    <td><tt>['phpenv']['php-build']['git_sync_path']</tt></td>
+    <td>String</td>
+    <td>Git repository cache path/td>
+    <td><tt>/tmp</tt></td>
+  </tr>
+  <tr>
     <td><tt>['phpenv']['php-build']['packages']</tt></td>
     <td>Array</td>
     <td>Packages to install</td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['phpenv']['git_reference'] = 'master'
 default['phpenv']['php-build']['git_force_update'] = false
 default['phpenv']['php-build']['git_repository'] = 'https://github.com/CHH/php-build.git'
 default['phpenv']['php-build']['git_reference'] = 'master'
+default['phpenv']['php-build']['git_sync_path'] = '/tmp'
 
 case platform
 when 'redhat', 'centos', 'fedora', 'amazon', 'scientific'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ user node['phpenv']['user'] do
   home node['phpenv']['user_home']
 end
 
-git '/tmp/phpenv' do
+git "#{node['phpenv']['php-build']['git_sync_path']}/phpenv" do
   user node['phpenv']['user']
   group node['phpenv']['group']
   repository node['phpenv']['git_repository']
@@ -57,7 +57,7 @@ end
 execute 'install-phpenv' do
   group node['phpenv']['group']
   user node['phpenv']['user']
-  cwd '/tmp/phpenv/bin'
+  cwd "#{node['phpenv']['php-build']['git_sync_path']}/phpenv/bin"
   command './phpenv-install.sh'
   environment 'PHPENV_ROOT' => dst_dir if dst_dir
   not_if do

--- a/spec/providers_spec/build_spec.rb
+++ b/spec/providers_spec/build_spec.rb
@@ -24,10 +24,6 @@ describe 'Chef::Provider::PhpenvBuild' do
     @provider = Chef::Platform.provider_for_resource(@resource, :build)
   end
 
-  after(:each) do
-    unload_resource(cookbook, lwrp)
-  end
-
   it 'should run phpenv build without parameter' do
     expect(@provider.action_run).to be_truthy
     expect(@runner).to run_phpenv_script('phpenv install 5.5.0 (system)').with(

--- a/spec/providers_spec/global_spec.rb
+++ b/spec/providers_spec/global_spec.rb
@@ -24,10 +24,6 @@ describe 'Chef::Provider::PhpenvGlobal' do
     @provider = Chef::Platform.provider_for_resource(@resource, :global)
   end
 
-  after(:each) do
-    unload_resource(cookbook, lwrp)
-  end
-
   it 'should run phpenv script without parameter' do
     expect(@provider.action_create).to be_truthy
     expect(@runner).to run_phpenv_script('phpenv global 5.4.0 (system)').with(

--- a/spec/providers_spec/script_spec.rb
+++ b/spec/providers_spec/script_spec.rb
@@ -24,10 +24,6 @@ describe 'Chef::Provider::PhpenvScript' do
     @provider = Chef::Platform.provider_for_resource(@resource, :script)
   end
 
-  after(:each) do
-    unload_resource(cookbook, lwrp)
-  end
-
   it 'should run phpenv script without parameter' do
     expect(@provider.action_run).to be_truthy
     expect(@runner).to run_script('execute-script').with(

--- a/spec/resources_spec/build_spec.rb
+++ b/spec/resources_spec/build_spec.rb
@@ -16,10 +16,6 @@ describe 'Chef::Resource::PhpenvBuild' do
     @resource = load_resource(cookbook, lwrp).new('5.4.0')
   end
 
-  after(:each) do
-    unload_resource(cookbook, lwrp)
-  end
-
   it 'should set the name and version' do
     expect(@resource.name).to eq('5.4.0')
     expect(@resource.version).to eq('5.4.0')

--- a/spec/resources_spec/global_spec.rb
+++ b/spec/resources_spec/global_spec.rb
@@ -16,10 +16,6 @@ describe 'Chef::Resource::PhpenvGlobal' do
     @resource = load_resource(cookbook, lwrp).new('5.4.0')
   end
 
-  after(:each) do
-    unload_resource(cookbook, lwrp)
-  end
-
   it 'should set the name and version' do
     expect(@resource.name).to eq('5.4.0')
     expect(@resource.phpenv_version).to eq('5.4.0')

--- a/spec/resources_spec/script_spec.rb
+++ b/spec/resources_spec/script_spec.rb
@@ -16,10 +16,6 @@ describe 'Chef::Resource::PhpenvScript' do
     @resource = load_resource(cookbook, lwrp).new('awesome-script')
   end
 
-  after(:each) do
-    unload_resource(cookbook, lwrp)
-  end
-
   it 'should set the name' do
     expect(@resource.name).to eq('awesome-script')
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,12 +24,8 @@ end
 module ResourceMixins
   def load_resource(cookbook, lwrp)
     file_path = File.join(File.dirname(__FILE__), '../resources', "#{lwrp}.rb")
-    Chef::Resource::LWRPBase
-      .build_from_file(cookbook, File.expand_path(file_path), nil)
-  end
-
-  def unload_resource(cookbook, lwrp)
-    Chef::Resource.send(:remove_const, lwrp_const(cookbook, lwrp))
+    resource = Chef::Resource::LWRPBase.build_from_file(cookbook, File.expand_path(file_path), nil)
+    resource == true ? loaded_resource(cookbook, lwrp) : resource
   end
 
   def resource_klass(cookbook, lwrp)
@@ -38,5 +34,9 @@ module ResourceMixins
 
   def lwrp_const(cookbook, lwrp)
     "#{cookbook.capitalize}#{lwrp.capitalize}"
+  end
+
+  def loaded_resource(cookbook, lwrp)
+    Chef::Resource.deprecated_constants[lwrp_const(cookbook, lwrp).intern]
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -37,7 +37,7 @@ require 'spec_helper'
   end
 end
 
-describe file('/tmp/phpenv') do
+describe file("#{node['phpenv']['php-build']['git_sync_path']}/phpenv") do
   it { should be_directory }
 end
 


### PR DESCRIPTION
If you git clone of destination to / tmp, because it may be removed in tmpwatch, it was to be specified directory.

* chef-exceptions
```
Mixlib::ShellOut::ShellCommandFailed: git[/tmp/phpenv] (phpenv::default line 41) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '128'
---- Begin output of git remote add origin https://github.com/CHH/phpenv.git ----
STDOUT: 
STDERR: fatal: Not a git repository (or any of the parent directories): .git
---- End output of git remote add origin https://github.com/CHH/phpenv.git ----
Ran git remote add origin https://github.com/CHH/phpenv.git returned 128
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/mixlib-shellout-2.0.1/lib/mixlib/shellout.rb:278:in `invalid!'
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/mixlib-shellout-2.0.1/lib/mixlib/shellout.rb:265:in `error!'
```